### PR TITLE
Test against Python 2 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.6"
   - "2.7"
 install:
-  - pip install doit
+  # The latest version of doit supporting Python 2 is 0.29.0
+  - test $(python -c 'import sys;print(sys.version_info[0])') -eq 2 && pip install 'doit==0.29.0' || pip install doit
 script:
   - doit test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.6"
+  - "2.7"
 install:
   - pip install doit
 script:

--- a/dodo.py
+++ b/dodo.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittests
 import sys
 


### PR DESCRIPTION
Pynance is written in Python 3, but should run in Python 2 as well. This PR will make Travis CI check the project in Python 2.7 too.