### PR TITLE
Add `requirements.txt` and doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ python:
   - "3.6"
   - "2.7"
 install:
-  - pip install pandas
-  - pip install numpy
-  # The latest version of doit supporting Python 2 is 0.29.0
-  - test $(python -c 'import sys;print(sys.version_info[0])') -eq 2 && pip install 'doit==0.29.0' || pip install doit
+  - pip install -r requirements.txt
 script:
   - doit test

--- a/pynance/dummy.py
+++ b/pynance/dummy.py
@@ -4,4 +4,10 @@ This is just a placeholder.
 """
 
 def my_dummy_function(number):
+    """
+    Dummy function that doubles its input.
+
+    >>> my_dummy_function(2)
+    4
+    """
     return 2*number

--- a/pynance/dummy_test.py
+++ b/pynance/dummy_test.py
@@ -12,6 +12,7 @@ class DummyTestCase(unittest.TestCase):
 
 
 def test_suite():
+    "returns test suite"
     suite = unittest.TestSuite()
     suite.addTest(DummyTestCase('test_my_dummy_function'))
     return suite

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pandas
+numpy
+codecov
+
+# The latest version of doit supporting Python 2 is 0.29.0
+doit==0.29.0; python_version < '3.0'
+doit; python_version >= '3.0'

--- a/unittests.py
+++ b/unittests.py
@@ -1,14 +1,33 @@
 #!/usr/bin/env python
 
 import unittest
+import doctest
 import pynance.dummy_test
 import pynance.textimporter_test
 
+def doc_test_suite():
+    "Returns the testsuite doctests for all modules. Please don't forget to add new modules here."
+
+    # Every module that doctests should be run on needs to present in the scope of the function.
+    # And they need to be added below.
+    import pynance
+    import pynance.dummy
+    import pynance.textimporter
+
+    # ... here:
+    doctest_suite = doctest.DocTestSuite(pynance.textimporter_test)
+    doctest_suite.addTest(doctest.DocTestSuite(pynance.dummy_test))
+    doctest_suite.addTest(doctest.DocTestSuite(pynance.dummy))
+    doctest_suite.addTest(doctest.DocTestSuite(pynance.textimporter))
+
+    return doctest_suite
 
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTests(pynance.dummy_test.test_suite())
     suite.addTests(pynance.textimporter_test.test_suite())
+
+    suite.addTest(doc_test_suite())
 
     return suite
 

--- a/unittests.py
+++ b/unittests.py
@@ -8,18 +8,21 @@ import pynance.textimporter_test
 def doc_test_suite():
     "Returns the testsuite doctests for all modules. Please don't forget to add new modules here."
 
-    # Every module that doctests should be run on needs to present in the scope of the function.
-    # And they need to be added below.
+    import pkgutil
+    import importlib
     import pynance
-    import pynance.dummy
-    import pynance.textimporter
 
-    # ... here:
-    doctest_suite = doctest.DocTestSuite(pynance.textimporter_test)
-    doctest_suite.addTest(doctest.DocTestSuite(pynance.dummy_test))
-    doctest_suite.addTest(doctest.DocTestSuite(pynance.dummy))
-    doctest_suite.addTest(doctest.DocTestSuite(pynance.textimporter))
+    doctest_suite = unittest.TestSuite()
+    def add_doctests_for_module(package):
+        "Recursively walks `package` and adds doctests for all submodules and subpackages to `doctest_suite`"
+        for _, name, is_pkg in pkgutil.walk_packages(package.__path__):
+            sub_module = importlib.import_module('{}.{}'.format(package.__name__, name))
+            if is_pkg:
+                add_doctests_for_module(sub_module)
+            else:
+                doctest_suite.addTest(doctest.DocTestSuite(sub_module))
 
+    add_doctests_for_module(pynance)
     return doctest_suite
 
 def test_suite():


### PR DESCRIPTION
This PR 

* adds `requirements.txt`
* adds doctests.

Note that this does not mean that we've decided against `conda`. This merely stores the dependencies and makes them visible. It should be easy to create `conda` environments from this.

Note that for Python 2, every module `doctest`ed now needs a docstring, otherwise [this](https://travis-ci.org/Sh4pe/pynance/jobs/487309439#L487) happens.

Closes #17. Closes #20.