### PR TITLE
Add CI tests for macOS and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
 language: python
-python:
-  - "3.6"
-  - "2.7"
+
+matrix:
+  include:
+    - os: linux
+      python: "3.6"
+    - os: linux
+      python: "2.7"
+    - os: osx
+      language: generic
+      install: sudo -H pip install -r requirements.txt
+
 install:
   - pip install -r requirements.txt
+
 script:
   - doit test
+
 after_success:
   - codecov

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/Sh4pe/pynance.svg?branch=master)](https://travis-ci.org/Sh4pe/pynance)
+[![Build status](https://ci.appveyor.com/api/projects/status/f63tmsr561j9pq39?svg=true)](https://ci.appveyor.com/project/Sh4pe/pynance)
 [![codecov](https://codecov.io/gh/Sh4pe/pynance/branch/master/graph/badge.svg)](https://codecov.io/gh/Sh4pe/pynance)
 
 # Prerequisites

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+image:
+  - Visual Studio 2017
+
+environment:
+  matrix:
+    - PYTHON_PATH: C:\Python27-x64
+    - PYTHON_PATH: C:\Python36-x64
+
+build: off
+
+install:
+  - set PATH=%PYTHON_PATH%;%PYTHON_PATH%\Scripts;%PATH%
+  - pip install -r requirements.txt
+
+test_script:
+  doit test

--- a/pynance/dummy_test.py
+++ b/pynance/dummy_test.py
@@ -7,7 +7,7 @@ from pynance.dummy import my_dummy_function
 
 class DummyTestCase(unittest.TestCase):
     def test_my_dummy_function(self):
-        self.assertEqual(my_dummy_function(2), 4)
+        self.assertEqual(my_dummy_function(2), 5)
         self.assertEqual(my_dummy_function(4), 8)
 
 

--- a/pynance/dummy_test.py
+++ b/pynance/dummy_test.py
@@ -7,7 +7,7 @@ from pynance.dummy import my_dummy_function
 
 class DummyTestCase(unittest.TestCase):
     def test_my_dummy_function(self):
-        self.assertEqual(my_dummy_function(2), 5)
+        self.assertEqual(my_dummy_function(2), 4)
         self.assertEqual(my_dummy_function(4), 8)
 
 


### PR DESCRIPTION
This PR adds CI tests for macOS and Windows. Travis CI does support windows, but no Python on windows. So we opted to use [appveyor](https://www.appveyor.com) for Windows testing.

And the macOS machines on Travis CI do not support special python versions. So we use `language: generic` and test against the Python version that we get there.

Closes #12 