### PR TITLE
Total balance fixes and visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ pynance/*.pyc
 .pytest_cache
 /.hypothesis
 .coverage
+/.local_test_data
+test_local.py

--- a/pynance/dash_viz/plot_flow.py
+++ b/pynance/dash_viz/plot_flow.py
@@ -195,7 +195,7 @@ def update_bar_chart(content, csvtype_str):
     Returns:
     --------
     Figure:
-        Bar chart figure, with time on x and amount on y
+        Bar chart figure, with time on x and total balance on y
     """
     if content is not None:
         df = parse_contents(content, csvtype_str)
@@ -222,7 +222,7 @@ def update_line(content, csvtype_str):
     Returns:
     --------
     Figure:
-        Bar chart figure, with time on x and amount on y
+        Line figure, with time on x and amount on y
     """
     if content is not None:
         df = parse_contents(content, csvtype_str)

--- a/pynance/dash_viz/plot_flow.py
+++ b/pynance/dash_viz/plot_flow.py
@@ -62,7 +62,15 @@ app.layout = html.Div([
             data=[],
         ),
         style={'height': 500},
-        id='my-graph'
+        id='graph_bar'
+    ),
+
+    dcc.Graph(
+        figure=go.Figure(
+            data=[],
+        ),
+        style={'height': 500},
+        id='graph_line'
     )
 ])
 
@@ -144,7 +152,20 @@ def make_cashflow_figure(df):
     return fig
 
 
-@app.callback(Output('my-graph', 'figure'),
+def make_line_figure(df):
+    """
+    """
+
+    lineplot = go.Scatter(x=df["date"],
+                          y=df["total_balance"])
+
+    fig = go.Figure(
+        data=[lineplot]
+    )
+    return fig
+
+
+@app.callback(Output('graph_bar', 'figure'),
               [Input('uploader', 'contents')],
               [State('csvtype', 'data')])
 def update_output(content, csvtype_str):
@@ -167,6 +188,33 @@ def update_output(content, csvtype_str):
     if content is not None:
         df = parse_contents(content, csvtype_str)
         return make_cashflow_figure(df)
+    else:
+        return go.Figure(data=[])
+
+
+@app.callback(Output('graph_line', 'figure'),
+              [Input('uploader', 'contents')],
+              [State('csvtype', 'data')])
+def update_line(content, csvtype_str):
+    """
+    Visualizes the raw data content of a file as a time-amount bar graph
+
+    Params:
+    -------
+    content: byte-like
+        undecoded csv file content
+    csvtype_str: str
+        name of a supported csv type, should be name of the attribute of
+        SupportedCsvTypes
+
+    Returns:
+    --------
+    Figure:
+        Bar chart figure, with time on x and amount on y
+    """
+    if content is not None:
+        df = parse_contents(content, csvtype_str)
+        return make_line_figure(df)
     else:
         return go.Figure(data=[])
 

--- a/pynance/dash_viz/plot_flow.py
+++ b/pynance/dash_viz/plot_flow.py
@@ -154,6 +154,18 @@ def make_cashflow_figure(df):
 
 def make_line_figure(df):
     """
+    Take a transactions dataframe and make a figure out of it, which
+    shows the total balance as a function of time
+
+    Params:
+    -------
+    df: pandas.Dataframe
+        Dataframe which must have the columns date and total_balance
+
+    Returns:
+    --------
+    plotly.graph_objs.Figure
+        Figure with the visualized data
     """
 
     lineplot = go.Scatter(x=df["date"],
@@ -168,7 +180,7 @@ def make_line_figure(df):
 @app.callback(Output('graph_bar', 'figure'),
               [Input('uploader', 'contents')],
               [State('csvtype', 'data')])
-def update_output(content, csvtype_str):
+def update_bar_chart(content, csvtype_str):
     """
     Visualizes the raw data content of a file as a time-amount bar graph
 
@@ -197,7 +209,7 @@ def update_output(content, csvtype_str):
               [State('csvtype', 'data')])
 def update_line(content, csvtype_str):
     """
-    Visualizes the raw data content of a file as a time-amount bar graph
+    Visualizes the raw data content of a file as a time-amount line graph
 
     Params:
     -------

--- a/pynance/dash_viz/plot_flow_test.py
+++ b/pynance/dash_viz/plot_flow_test.py
@@ -155,7 +155,7 @@ class DashTestCase(unittest.TestCase):
         res_chart = result_fig._data[0]
 
         assert_array_equal(balances, res_chart['y'])
-        self.assertEqual(final_balance, res_chart['y'][-1])
+        self.assertEqual(final_balance, res_chart['y'][0])
 
     def test_update_output_None(self):
         self.assertFalse(update_bar_chart(None, "") is None)

--- a/pynance/dash_viz/plot_flow_test.py
+++ b/pynance/dash_viz/plot_flow_test.py
@@ -10,7 +10,7 @@ import pandas as pd
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from .plot_flow import app, csvtype_string2description, update_output,\
+from .plot_flow import app, csvtype_string2description, update_bar_chart,\
     onselect_csvtype, update_csvtype_store, make_cashflow_figure, \
     parse_contents
 from ..dkb import SupportedCsvTypes
@@ -130,7 +130,7 @@ class DashTestCase(unittest.TestCase):
         self.assertEqual(len(all_y_values), len(amounts))
 
     def test_update_output_None(self):
-        self.assertFalse(update_output(None, "") is None)
+        self.assertFalse(update_bar_chart(None, "") is None)
 
     def test_update_output(self):
         expected_amount = np.array([-12.16,
@@ -139,7 +139,7 @@ class DashTestCase(unittest.TestCase):
 
         bytestr = self._read_sample_file_like_uploaded()
 
-        response = update_output(bytestr, "DKBCash")
+        response = update_bar_chart(bytestr, "DKBCash")
         response_dict = json.loads(response.data.decode())
 
         res_charts = response_dict["response"]["props"]["figure"]["data"]

--- a/pynance/dash_viz/plot_flow_test.py
+++ b/pynance/dash_viz/plot_flow_test.py
@@ -10,7 +10,8 @@ import pandas as pd
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from .plot_flow import app, csvtype_string2description, update_bar_chart,\
+from .plot_flow import app, csvtype_string2description, \
+    update_bar_chart, update_line, \
     onselect_csvtype, update_csvtype_store, make_cashflow_figure, \
     make_line_figure, parse_contents
 from ..dkb import SupportedCsvTypes
@@ -160,7 +161,7 @@ class DashTestCase(unittest.TestCase):
     def test_update_output_None(self):
         self.assertFalse(update_bar_chart(None, "") is None)
 
-    def test_update_output(self):
+    def test_update_bar_chart(self):
         expected_amount = np.array([-12.16,
                                     120.0,
                                     -10.0]).astype(np.float64)
@@ -179,6 +180,21 @@ class DashTestCase(unittest.TestCase):
 
         assert_array_equal(np.sort(all_y_values),
                            np.sort(expected_amount))
+
+    def test_update_line(self):
+        expected_balance = np.array([1248.54,
+                                     1260.70,
+                                     1140.70]).astype(np.float64)
+
+        bytestr = self._read_sample_file_like_uploaded()
+
+        response = update_line(bytestr, "DKBCash")
+        response_dict = json.loads(response.data.decode())
+
+        res_chart = response_dict["response"]["props"]["figure"]["data"][0]
+
+        assert_array_equal(res_chart['y'],
+                           expected_balance)
 
 
 def test_suite():

--- a/pynance/dash_viz/plot_flow_test.py
+++ b/pynance/dash_viz/plot_flow_test.py
@@ -12,8 +12,9 @@ from numpy.testing import assert_array_equal
 
 from .plot_flow import app, csvtype_string2description, update_bar_chart,\
     onselect_csvtype, update_csvtype_store, make_cashflow_figure, \
-    parse_contents
+    make_line_figure, parse_contents
 from ..dkb import SupportedCsvTypes
+from ..textimporter import amounts_to_balances
 
 
 class DashTestCase(unittest.TestCase):
@@ -80,7 +81,7 @@ class DashTestCase(unittest.TestCase):
         self.assertListEqual(expected_sender,
                              list(result_df["sender_account"].values))
 
-    def test_make_figure(self):
+    def test_make_bar_chart(self):
         amounts = [12.34,
                    -20,
                    0,
@@ -128,6 +129,33 @@ class DashTestCase(unittest.TestCase):
         # total number of y values should be the number
         # of values in amounts
         self.assertEqual(len(all_y_values), len(amounts))
+
+    def test_make_balance_line_chart(self):
+        amounts = [12.34,
+                   -20,
+                   0,
+                   456.32]
+        dates = ["2018-10-02",
+                 "2018-12-03",
+                 "2019-01-22",
+                 "2019-02-27"]
+        texts = ["payback 1",
+                 "text2",
+                 "cash text",
+                 "your money"]
+
+        final_balance = 1000.00
+
+        balances = amounts_to_balances(amounts, final_balance)
+
+        df = pd.DataFrame([{"total_balance": b, "date": d, "text": t}
+                           for b, d, t in zip(balances, dates, texts)])
+
+        result_fig = make_line_figure(df)
+        res_chart = result_fig._data[0]
+
+        assert_array_equal(balances, res_chart['y'])
+        self.assertEqual(final_balance, res_chart['y'][-1])
 
     def test_update_output_None(self):
         self.assertFalse(update_bar_chart(None, "") is None)

--- a/pynance/dkb.py
+++ b/pynance/dkb.py
@@ -75,7 +75,7 @@ class SupportedCsvTypes():
         skiprows=6,
         encoding="iso-8859-1",
         total_balance_re_pattern=r'(?<=Kontostand vom \d{2}.\d{2}.\d{4}:";")'
-                                 r'(\d+,\d+)')
+                                 r'(.*)(?= EUR";)')
 
     DKBVisa = CsvFileDescription(
         column_map={
@@ -87,4 +87,4 @@ class SupportedCsvTypes():
         formatters=DKBFormatters.formatter_map(),
         skiprows=6,
         encoding="iso-8859-1",
-        total_balance_re_pattern=r'(?<=Saldo:";")(\d+,\d+)')
+        total_balance_re_pattern=r'(?<=Saldo:";")(.*)(?= EUR";)')

--- a/pynance/dkb.py
+++ b/pynance/dkb.py
@@ -38,6 +38,10 @@ class DKBFormatters():
             return float(numberstring.replace(".", "").replace(",", "."))
 
     @classmethod
+    def to_float64_VISA_header(cls, numberstring):
+        return float(numberstring)
+
+    @classmethod
     def formatter_map(cls):
         return {
             np.datetime64: cls.to_datetime64,
@@ -75,7 +79,8 @@ class SupportedCsvTypes():
         skiprows=6,
         encoding="iso-8859-1",
         total_balance_re_pattern=r'(?<=Kontostand vom \d{2}.\d{2}.\d{4}:";")'
-                                 r'(.*)(?= EUR";)')
+                                 r'(.*)(?= EUR";)',
+        total_balance_formatter=DKBFormatters.to_float64)
 
     DKBVisa = CsvFileDescription(
         column_map={
@@ -87,4 +92,5 @@ class SupportedCsvTypes():
         formatters=DKBFormatters.formatter_map(),
         skiprows=6,
         encoding="iso-8859-1",
-        total_balance_re_pattern=r'(?<=Saldo:";")(.*)(?= EUR";)')
+        total_balance_re_pattern=r'(?<=Saldo:";")(.*)(?= EUR";)',
+        total_balance_formatter=DKBFormatters.to_float64_VISA_header)

--- a/pynance/test_data/dkb_cash_sample.csv
+++ b/pynance/test_data/dkb_cash_sample.csv
@@ -2,7 +2,7 @@
 
 "Von:";"01.12.2018";
 "Bis:";"15.12.2018";
-"Kontostand vom 15.12.2018:";"248,54 EUR";
+"Kontostand vom 15.12.2018:";"1.248,54 EUR";
 
 "Buchungstag";"Wertstellung";"Buchungstext";"Auftraggeber / Begünstigter";"Verwendungszweck";"Kontonummer";"BLZ";"Betrag (EUR)";"Gläubiger-ID";"Mandatsreferenz";"Kundenreferenz";
 "04.12.2018";"04.12.2018";"Lastschrift";""PayPal (Europe) S.a.r.l. et Cie.";"PP.4882.PP . FLIXBUS, Ihr Einkauf bei FLIXBUS";"DE39500105174461799382 ";"DEUTDEFFXXX";"-12,16";"LU96ZZZ0000000000000000058                       ";"4SP2224T3WZC4         ";"";

--- a/pynance/test_data/dkb_visa_sample.csv
+++ b/pynance/test_data/dkb_visa_sample.csv
@@ -1,7 +1,7 @@
 "Kreditkarte:";"3546********6546";
 
 "Zeitraum:";"letzten 60 Tage";
-"Saldo:";"465,33 EUR";
+"Saldo:";"465.33 EUR";
 "Datum:";"28.01.2019";
 
 "Umsatz abgerechnet und nicht im Saldo enthalten";"Wertstellung";"Belegdatum";"Beschreibung";"Betrag (EUR)";"Ursprünglicher Betrag";

--- a/pynance/textimporter.py
+++ b/pynance/textimporter.py
@@ -91,7 +91,9 @@ def amounts_to_balances(amounts, final_balance):
     PARAMS:
     -------
     amounts : iterable of float
-        amount transferred for each transaction
+        amount transferred for each transaction. It must be ordered,
+        such that the latest performed transaction is *first* in the
+        list
     final_balance : float
         total value of the balance after the last transaction
 
@@ -101,8 +103,8 @@ def amounts_to_balances(amounts, final_balance):
         values of the total balance after each transaction
     """
 
-    accumulated = np.cumsum(np.array(amounts, dtype=float))
-    return accumulated - accumulated[-1] + final_balance
+    accumulated = np.cumsum(np.array(amounts[::-1], dtype=float))[::-1]
+    return accumulated - accumulated[0] + final_balance
 
 
 class CsvFileDescription():

--- a/pynance/textimporter.py
+++ b/pynance/textimporter.py
@@ -116,7 +116,8 @@ class CsvFileDescription():
                  formatters,
                  skiprows,
                  encoding,
-                 total_balance_re_pattern):
+                 total_balance_re_pattern,
+                 total_balance_formatter):
         """
         A description of a specific CSV file design.
         Typically a definition for a specific bank transaction CSV file
@@ -136,6 +137,9 @@ class CsvFileDescription():
             encoding of the csv file, e.g. 'utf-8' or 'iso-8859-1'
         total_balance_re_pattern : string
             regex expression, that matches for the final total balance
+        total_balance_formatter : function : string -> float
+            a function that is applied to the string matched by
+            total_balance_re_pattern and return the number
         """
 
         # check that for every type in COLUMN, there is a formatter
@@ -148,6 +152,7 @@ class CsvFileDescription():
         self.skiprows = skiprows
         self.encoding = encoding
         self.total_balance_re_pattern = total_balance_re_pattern
+        self.total_balance_formatter = total_balance_formatter
 
     def read_total_balance(self, filepath_or_buffer):
         """
@@ -178,8 +183,7 @@ class CsvFileDescription():
             for line in buffer.readlines():
                 match = re.search(self.total_balance_re_pattern, line)
                 if match:
-                    target_type = COLUMNS['total_balance']
-                    formatter = self.formatters[target_type]
+                    formatter = self.total_balance_formatter
                     return formatter(match.group(0))
 
             raise UnsupportedCsvFormatException(

--- a/pynance/textimporter_balance_test.py
+++ b/pynance/textimporter_balance_test.py
@@ -46,14 +46,18 @@ class CsvBalanceImportTestCase(unittest.TestCase):
 
         # check if the balance at the end is equal to the value
         # given in the header
+        # the first value in the df is the latest, i.e. the final row
         self.assertEqual(final_balance_dkbcash,
-                         dkb_cash_sample_df['total_balance'].iloc[-1])
+                         dkb_cash_sample_df['total_balance'].iloc[0])
         self.assertEqual(final_balance_dkbvisa,
-                         dkb_visa_sample_df['total_balance'].iloc[-1])
+                         dkb_visa_sample_df['total_balance'].iloc[0])
 
     def test_read_all_balance_dkbcash(self):
         dkb_cash_sample_df = self.read_dummy_file_dkbcash_small()
-        balances_dkbcash = [1138.54, 1258.54, 1248.54]
+
+        # final 1248.54
+        # amounts: -12.16, 120, -10
+        balances_dkbcash = [1248.54, 1260.70, 1140.70]
 
         assert_array_almost_equal(balances_dkbcash,
                                   dkb_cash_sample_df['total_balance'].tolist())
@@ -67,7 +71,7 @@ class CsvBalanceImportTestCase(unittest.TestCase):
             balances = df['total_balance'].tolist()
 
             for i in range(len(amounts)-1):
-                assert_almost_equal(balances[i+1], balances[i]+amounts[i+1])
+                assert_almost_equal(balances[i], balances[i+1]+amounts[i])
 
     def test_dkbcash_balance_regex_match(self):
         dummyfile_dkbcash_small = os.path.join("pynance",
@@ -83,7 +87,7 @@ class CsvBalanceImportTestCase(unittest.TestCase):
 
     def test_dkbcash_final_balance(self):
         dkb_cash_sample_df = self.read_dummy_file_dkbcash_small()
-        final_balance = dkb_cash_sample_df["total_balance"].tolist()[-1]
+        final_balance = dkb_cash_sample_df["total_balance"].tolist()[0]
         expected_balance = 1248.54
 
         self.assertEqual(expected_balance, final_balance)
@@ -139,7 +143,7 @@ class CsvBalanceImportTestCase(unittest.TestCase):
     def test_amounts_to_balances1(self):
         amounts = np.array([1.0, 1.0, 1.0, 1.0])
         final_balance = 4.0
-        expected_balances = np.array([1.0, 2.0, 3.0, 4.0])
+        expected_balances = np.array([4.0, 3.0, 2.0, 1.0])
 
         balances = amounts_to_balances(amounts, final_balance)
         assert_array_almost_equal(expected_balances, balances)
@@ -147,7 +151,7 @@ class CsvBalanceImportTestCase(unittest.TestCase):
     def test_amounts_to_balances2(self):
         amounts = np.array([-12.23, 9.00, 453.23, -232.32])
         final_balance = 221.32
-        expected_balances = np.array([-8.59, 0.41, 453.64, 221.32])
+        expected_balances = np.array([221.32, 233.55, 224.55, -228.68])
 
         balances = amounts_to_balances(amounts, final_balance)
         assert_array_almost_equal(expected_balances, balances)
@@ -159,9 +163,9 @@ class CsvBalanceImportTestCase(unittest.TestCase):
         balances = amounts_to_balances(amounts, final_balance)
 
         for i in range(len(amounts)-1):
-            assert_almost_equal(balances[i+1], balances[i]+amounts[i+1])
+            assert_almost_equal(balances[i], balances[i+1]+amounts[i])
 
-        self.assertEqual(balances[-1], final_balance)
+        self.assertEqual(balances[0], final_balance)
 
 
 def test_suite():

--- a/pynance/textimporter_balance_test.py
+++ b/pynance/textimporter_balance_test.py
@@ -111,7 +111,7 @@ class CsvBalanceImportTestCase(unittest.TestCase):
             "Kreditkarte:";"3546********6546";
 
             "Zeitraum:";"letzten 60 Tage";
-            "Saldo:";"465,33 EUR";
+            "Saldo:";"465.33 EUR";
             "Datum:";"28.01.2019";
 
             "Umsatz abgerechnet und nicht im Saldo enthalte
@@ -128,7 +128,7 @@ class CsvBalanceImportTestCase(unittest.TestCase):
             "Kreditkarte:";"3546********6546";
 
             "Zeitraum:";"letzten 60 Tage";
-            "BALANCE:";"465,33 EUR";
+            "BALANCE:";"465.33 EUR";
             "Datum:";"28.01.2019";
 
             "Umsatz abgerechnet und nicht im Saldo enthalte

--- a/pynance/textimporter_balance_test.py
+++ b/pynance/textimporter_balance_test.py
@@ -39,7 +39,7 @@ class CsvBalanceImportTestCase(unittest.TestCase):
         after the last transaction of that file
         """
         dkb_cash_sample_df = self.read_dummy_file_dkbcash_small()
-        final_balance_dkbcash = 248.54
+        final_balance_dkbcash = 1248.54
 
         dkb_visa_sample_df = self.read_dummy_file_dkbvisa_small()
         final_balance_dkbvisa = 465.33
@@ -53,7 +53,7 @@ class CsvBalanceImportTestCase(unittest.TestCase):
 
     def test_read_all_balance_dkbcash(self):
         dkb_cash_sample_df = self.read_dummy_file_dkbcash_small()
-        balances_dkbcash = [138.54, 258.54, 248.54]
+        balances_dkbcash = [1138.54, 1258.54, 1248.54]
 
         assert_array_almost_equal(balances_dkbcash,
                                   dkb_cash_sample_df['total_balance'].tolist())
@@ -75,7 +75,7 @@ class CsvBalanceImportTestCase(unittest.TestCase):
                                                "dkb_cash_sample.csv")
 
         csv_desc = SupportedCsvTypes.DKBCash
-        expected_balance = 248.54
+        expected_balance = 1248.54
 
         balance = csv_desc.read_total_balance(dummyfile_dkbcash_small)
 

--- a/pynance/textimporter_balance_test.py
+++ b/pynance/textimporter_balance_test.py
@@ -81,6 +81,13 @@ class CsvBalanceImportTestCase(unittest.TestCase):
 
         self.assertEqual(expected_balance, balance)
 
+    def test_dkbcash_final_balance(self):
+        dkb_cash_sample_df = self.read_dummy_file_dkbcash_small()
+        final_balance = dkb_cash_sample_df["total_balance"].tolist()[-1]
+        expected_balance = 1248.54
+
+        self.assertEqual(expected_balance, final_balance)
+
     def test_dkbvisa_balance_regex_match(self):
         dummyfile_dkbvisa_small = os.path.join("pynance",
                                                "test_data",
@@ -130,6 +137,14 @@ class CsvBalanceImportTestCase(unittest.TestCase):
         self.assertRaises(UnsupportedCsvFormatException, parse_invald_header)
 
     def test_amounts_to_balances1(self):
+        amounts = np.array([1.0, 1.0, 1.0, 1.0])
+        final_balance = 4.0
+        expected_balances = np.array([1.0, 2.0, 3.0, 4.0])
+
+        balances = amounts_to_balances(amounts, final_balance)
+        assert_array_almost_equal(expected_balances, balances)
+
+    def test_amounts_to_balances2(self):
         amounts = np.array([-12.23, 9.00, 453.23, -232.32])
         final_balance = 221.32
         expected_balances = np.array([-8.59, 0.41, 453.64, 221.32])
@@ -137,7 +152,7 @@ class CsvBalanceImportTestCase(unittest.TestCase):
         balances = amounts_to_balances(amounts, final_balance)
         assert_array_almost_equal(expected_balances, balances)
 
-    def test_amounts_to_balances2(self):
+    def test_amounts_to_balances3(self):
         np.random.seed(0)
         amounts = np.random.random(100)*1000 - np.random.randint(300, 500)
         final_balance = np.random.random()*10000

--- a/pynance/textimporter_test.py
+++ b/pynance/textimporter_test.py
@@ -54,7 +54,8 @@ class CsvImportTestCase(unittest.TestCase):
                 encoding="iso-8859-1",
                 total_balance_re_pattern=r'(?<=Kontostand vom '
                                          r'\d{2}.\d{2}.\d{4}:";")'
-                                         r'(\d+,\d+)')
+                                         r'(\d+,\d+)',
+                total_balance_formatter=DKBFormatters.to_float64)
         self.assertRaises(AssertionError, construction_missing_formatter)
 
     # tests DKB
@@ -257,7 +258,7 @@ class CsvImportTestCase(unittest.TestCase):
             "Kreditkarte:";"3546********6546";
 
             "Zeitraum:";"letzten 60 Tage";
-            "Saldo:";"465,33 EUR";
+            "Saldo:";"465.33 EUR";
             "Datum:";"28.01.2019";
             """\
             u'"Umsatz abgerechnet und nicht im Saldo enthalten";'\


### PR DESCRIPTION
This PR introduces an additional chart in the dash app, which shows the total balance.
Additionally it fixes some serious bugs with the `total_balance` column and parsing of DKB VISA csv files.

Closes #43, closes #48, closes #50 and closes #51 